### PR TITLE
Allow override of sane default listening address

### DIFF
--- a/source/main.d
+++ b/source/main.d
@@ -16,14 +16,14 @@
 module main;
 
 import libsodium;
+import moss.service.models;
 import moss.service.server;
+import std.getopt;
 import std.path : absolutePath, asNormalizedPath;
 import vessel.app;
 import vessel.models;
-import moss.service.models;
 import vessel.setup;
 import vibe.d;
-import std.getopt;
 
 /**
  * Main entry point for vessel
@@ -35,11 +35,13 @@ import std.getopt;
 int main(string[] args)
 {
     ushort portNumber = 5050;
-    string[] addresses = ["::", "0.0.0.0"];
+    /* It's safer to set this to localhost and allow the user to override (not append!) */
+    static string[] defaultAddress = ["localhost"];
+    string[] cmdLineAddresses;
 
     auto opts = () @trusted {
         return getopt(args, config.bundling, "p|port", "Specific port to serve on",
-                &portNumber, "a|address", "Host address to bind to", &addresses);
+                &portNumber, "a|address", "Host address to bind to", &cmdLineAddresses);
     }();
 
     if (opts.helpWanted)
@@ -59,7 +61,7 @@ int main(string[] args)
     {
         server.close();
     }
-    server.serverSettings.bindAddresses = addresses;
+    server.serverSettings.bindAddresses = cmdLineAddresses.empty ? defaultAddress : cmdLineAddresses;
     server.serverSettings.port = portNumber;
     server.serverSettings.serverString = "vessel/0.1";
     server.serverSettings.sessionIdCookie = "vessel.session_id";


### PR DESCRIPTION
This commit makes the service listen on localhost by default when no address command line parameters are specified.

If any address command line parameters are specified, they will be added to an initially empty dynamic address array in the listed order, thus overriding the default listening address.